### PR TITLE
chore: use dev-shells flake for go dev environment

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake "github:sbfaulkner/dev-shells#go-1-26"

--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,10 @@
 use flake "github:sbfaulkner/dev-shells#go-1-26"
 use flake "github:sbfaulkner/dev-shells#ragel"
+
+watch_file go.mod
+watch_file go.sum
+
+if ! go list -m all >/dev/null 2>&1; then
+  echo "Fetching Go modules..."
+  go mod download
+fi

--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,2 @@
 use flake "github:sbfaulkner/dev-shells#go-1-26"
+use flake "github:sbfaulkner/dev-shells#ragel"


### PR DESCRIPTION
Switch .envrc to use dev-shells go-1-26 from github:sbfaulkner/dev-shells#go-1-26